### PR TITLE
xtensa: fix PR target/90922

### DIFF
--- a/gcc/config/xtensa/xtensa.c
+++ b/gcc/config/xtensa/xtensa.c
@@ -2726,7 +2726,8 @@ xtensa_expand_prologue (void)
 			    gen_rtx_SET (VOIDmode, mem, reg));
 	    }
 	}
-      if (total_size > 1024)
+      if (total_size > 1024
+	  || (!xtensa_callee_save_size && total_size > 128))
 	{
 	  rtx tmp_reg = gen_rtx_REG (Pmode, A9_REG);
 	  emit_move_insn (tmp_reg, GEN_INT (total_size - xtensa_callee_save_size));


### PR DESCRIPTION
Stack pointer adjustment code in prologue missed a case of no
callee-saved registers and a stack frame size bigger than 128 bytes.
Handle that case.

This fixes the following gcc tests with call0 ABI:
  gcc.c-torture/execute/stdarg-2.c
  gcc.dg/torture/pr55882.c
  gcc.dg/torture/pr57569.c

2019-06-18  Max Filippov  <jcmvbkbc@gmail.com>
gcc/
	* config/xtensa/xtensa.c (xtensa_expand_prologue): Add stack
	pointer adjustment for the case of no callee-saved registers and
	stack frame bigger than 128 bytes.

git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/trunk@272455 138bc75d-0d04-0410-961f-82ee72b054a4
Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>